### PR TITLE
Use ember-auto-import to lazy load the script

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: 'babel-eslint',
   root: true,
   parserOptions: {
     ecmaVersion: 2017,

--- a/addon/components/hello-sign.js
+++ b/addon/components/hello-sign.js
@@ -1,8 +1,9 @@
-/* global HelloSign */
 import { assert } from '@ember/debug';
 
 import { isNone } from '@ember/utils';
 import Component from '@ember/component';
+import { reads } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
 import config from 'ember-get-config';
 import layout from '../templates/components/hello-sign';
 
@@ -28,6 +29,10 @@ const helloSignConfig = config.HelloSign;
 */
 export default Component.extend({
   layout: layout,
+
+  helloSignLoader: service('hello-sign'),
+
+  hellosign: reads('helloSignLoader.hellosign'),
 
   // Required attributes
 
@@ -100,7 +105,7 @@ export default Component.extend({
    @argument userCulture
    @type String?
    */
-  userCulture: HelloSign.CULTURES.EN_US,
+  userCulture: undefined,
 
   /**
    * When true, the header will be hidden (default = false).
@@ -177,7 +182,11 @@ export default Component.extend({
       assert(message);
     }
 
-    HelloSign.init(helloSignConfig.key);
+    this.get('hellosign').init(helloSignConfig.key);
+
+    if (!this.get('userCulture')) {
+      this.set('userCulture', this.get('hellosign').CULTURES.EN_US);
+    }
 
     let options = this.getProperties([
       'allowCancel',
@@ -201,13 +210,13 @@ export default Component.extend({
 
     options.messageListener = eventData => {
       switch (eventData.event) {
-        case HelloSign.EVENT_SIGNED:
+        case this.hellosign.EVENT_SIGNED:
           this.get('onEventSigned')(eventData);
           break;
-        case HelloSign.EVENT_CANCELED:
+        case this.hellosign.EVENT_CANCELED:
           this.get('onEventCanceled')();
           break;
-        case HelloSign.EVENT_ERROR:
+        case this.hellosign.EVENT_ERROR:
           this.get('onEventError')(eventData);
           break;
         default:
@@ -215,6 +224,6 @@ export default Component.extend({
       }
     };
 
-    HelloSign.open(options);
+    this.get('hellosign').open(options);
   }
 });

--- a/addon/components/hello-sign.js
+++ b/addon/components/hello-sign.js
@@ -1,13 +1,10 @@
 import { assert } from '@ember/debug';
-
 import { isNone } from '@ember/utils';
 import Component from '@ember/component';
+import { getOwner } from '@ember/application';
 import { reads } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import config from 'ember-get-config';
 import layout from '../templates/components/hello-sign';
-
-const helloSignConfig = config.HelloSign;
 
 /**
   A component to open the HelloSign contract. Usage:
@@ -182,7 +179,8 @@ export default Component.extend({
       assert(message);
     }
 
-    this.get('hellosign').init(helloSignConfig.key);
+    const config = getOwner(this).resolveRegistration('config:environment');
+    this.get('hellosign').init(config.HelloSign.key);
 
     if (!this.get('userCulture')) {
       this.set('userCulture', this.get('hellosign').CULTURES.EN_US);

--- a/addon/services/hello-sign.js
+++ b/addon/services/hello-sign.js
@@ -1,0 +1,16 @@
+import Service from '@ember/service';
+import { resolve } from 'rsvp';
+
+export default Service.extend({
+  hellosign: null,
+
+  load() {
+    if (this.hellosign) {
+      return resolve();
+    }
+
+    return import('hellosign-embedded').then(module => {
+      this.set('hellosign', module.default);
+    });
+  }
+});

--- a/app/services/hello-sign.js
+++ b/app/services/hello-sign.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-hellosign/services/hello-sign';

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    // Add options here
+    babel: {
+      plugins: [require('ember-auto-import/babel-plugin')]
+    }
   });
 
   /*

--- a/index.js
+++ b/index.js
@@ -3,9 +3,12 @@
 module.exports = {
   name: require('./package').name,
 
-  contentFor: function(name) {
-    if (name === 'body') {
-      return '<script type="text/javascript" src="https://s3.amazonaws.com/cdn.hellosign.com/public/js/hellosign-embedded.LATEST.min.js"></script>';
+  options: {
+    babel: {
+      plugins: [
+        // Ensure that `ember-auto-import` can handle the dynamic imports
+        require('ember-auto-import/babel-plugin')
+      ]
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "ember-cli-uglify": "^2.1.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
-    "ember-get-config": "^0.2.2",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,14 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
+    "ember-auto-import": "^1.2.21",
     "ember-cli-babel": "^7.1.2",
-    "ember-cli-htmlbars": "^3.0.0"
+    "ember-cli-htmlbars": "^3.0.0",
+    "hellosign-embedded": "^1.6.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",
+    "babel-eslint": "^10.0.1",
     "broccoli-asset-rev": "^2.7.0",
     "ember-cli": "^3.7.1",
     "ember-cli-addon-docs": "^0.6.7",

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,10 +1,3 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
 
-export default Route.extend({
-  helloSign: service(),
-
-  beforeModel() {
-    return this.helloSign.load();
-  }
-});
+export default Route.extend({});

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default Route.extend({
+  helloSign: service(),
+
+  beforeModel() {
+    return this.helloSign.load();
+  }
+});

--- a/tests/dummy/app/templates/docs.hbs
+++ b/tests/dummy/app/templates/docs.hbs
@@ -1,8 +1,8 @@
 {{#docs-viewer as |viewer|}}
   {{#viewer.nav as |nav|}}
-    {{nav.section "Getting started"}}
+    {{nav.section "Quick Start"}}
 
-    {{nav.item "Quick Start" "docs.index"}}
+    {{nav.item "Installation" "docs.index"}}
     {{nav.item "Usage" "docs.usage"}}
   {{/viewer.nav}}
 

--- a/tests/dummy/app/templates/docs/index.md
+++ b/tests/dummy/app/templates/docs/index.md
@@ -1,17 +1,10 @@
-# Quick Start
+# Installation
 
-## Installation
-
+The addon may be installed through:
 ```
 ember install ember-cli-hellosign
 ```
 
-## Setup
-Add your HelloSign **publishable key** to your app's config
-
-
-{{#docs-snippet name='config-environment.js' language='javascript' title='config/environment.js'}}
-  ENV.HelloSign = {
-    key: "abc"
-  };
-{{/docs-snippet}}
+It could be installed directly via `yarn add -D ember-cli-hellosign` /
+`npm install --save-dev ember-cli-hellosign` as well. Inded, it does not contain
+any ember-specific blueprint.

--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -1,17 +1,60 @@
 # Usage
 
-## Basic Usage
-```handlebars
-{{hello-sign url=signUrl}}
+## Setup
+Add your HelloSign **publishable key** to your app's config
+
+
+{{#docs-snippet name='config-environment.js' language='javascript' title='config/environment.js'}}
+  ENV.HelloSign = {
+    key: "abc"
+  };
+{{/docs-snippet}}
+
+## Loading the library
+
+In a first step, you'll have to explicitely load the library. This addon
+exposes a service to do so:
+```javascript
+export default class ContractController extends Controller {
+  @service helloSign;
+
+  // when the user clicks on the button "Sign my contract"
+  // it may be done alternatively your route's model
+  @action
+  handleContractOpen() {
+    return this.helloSign.load();
+  }
+}
 ```
 
-## Heavier Usage
+The loading is done through a dynamic import and uses
+[ember-auto-import](https://github.com/ef4/ember-auto-import) under the hood.
+
+## Basic Usage
+In your template, when the library is loaded, you can use this snippet:
+```handlebars
+{{hello-sign
+  url=signUrl
+  onEventCanceled=(action "handleEventCanceled")
+  onEventError=(action "handleEventError")
+  onEventSigned=(action "handleEventSigned")
+}}
+```
+
+Note that the `signUrl` has to generated against HelloSign API.
+
+## More Advanced Usage
+In a more advanced usage, you may want to use some additional parameters. They
+are detailed in the {{docs-link 'API REFERENCE section' 'docs.api.item' 'components/hello-sign'}}.
 ```handlebars
 {{hello-sign
   url=signUrl
   allowCancel=false
   debug=true
   skipDomainVerification=true
-  height=320
+  onEventInvalid=(action "handleEventInvalid")
+  onEventCanceled=(action "handleEventCanceled")
+  onEventError=(action "handleEventError")
+  onEventSigned=(action "handleEventSigned")
 }}
 ```

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -24,7 +24,7 @@
 
     <div class="docs-my-16 docs-text-right">
       {{#link-to
-        "docs"
+        "docs.index"
         class="docs-bg-grey-darkest hover:docs-bg-black docs-text-white docs-py-2 docs-px-4 docs-no-underline docs-rounded"
       }}
         Read the docs →

--- a/tests/integration/components/hello-sign-test.js
+++ b/tests/integration/components/hello-sign-test.js
@@ -23,6 +23,8 @@ module('Integration | Component | hello sign', function(hooks) {
   test('it throws error if Signing URL is not provided', async function(assert) {
     assert.expect(1);
 
+    await this.owner.lookup('service:hello-sign').load();
+
     let expectedMessage = 'SignUrl must be set to use the hello-sign component';
 
     // https://github.com/workmanw/ember-qunit-assert-helpers/issues/18

--- a/tests/unit/services/hello-sign-test.js
+++ b/tests/unit/services/hello-sign-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | hello-sign', function(hooks) {
+  setupTest(hooks);
+
+  test('load the library', async function(assert) {
+    let service = this.owner.lookup('service:hello-sign');
+    assert.notOk(service.hellosign);
+    await service.load();
+    assert.ok(service.hellosign);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2882,14 +2882,6 @@ broccoli-debug@^0.6.2:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
-broccoli-file-creator@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz#27f1b25b1b00e7bb7bf3d5d7abed5f4d5388df4d"
-  integrity sha512-l9zthHg6bAtnOfRr/ieZ1srRQEsufMZID7xGYRW3aBDv3u/3Eux+Iawl10tAGYE5pL9YB4n5X4vxkp6iNOoZ9g==
-  dependencies:
-    broccoli-plugin "^1.1.0"
-    mkdirp "^0.5.1"
-
 broccoli-file-creator@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz#7351dd2496c762cfce7736ce9b49e3fce0c7b7db"
@@ -4887,7 +4879,7 @@ ember-cli-babel-plugin-helpers@^1.1.0:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz#de3baedd093163b6c2461f95964888c1676325ac"
   integrity sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA==
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -5582,14 +5574,6 @@ ember-fetch@^6.2.0:
     ember-cli-babel "^6.8.2"
     node-fetch "^2.3.0"
     whatwg-fetch "^3.0.0"
-
-ember-get-config@^0.2.2:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
-  integrity sha1-EYSSoqA9c+RgBO13eSiUICH+Hs0=
-  dependencies:
-    broccoli-file-creator "^1.1.1"
-    ember-cli-babel "^6.3.0"
 
 ember-getowner-polyfill@^2.0.1, ember-getowner-polyfill@^2.2.0:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,15 +306,15 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/parser@^7.0.0", "@babel/parser@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.4.tgz#a43357e4bbf4b92a437fb9e465c192848287f27c"
+  integrity sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==
+
 "@babel/parser@^7.2.2", "@babel/parser@^7.2.3", "@babel/parser@^7.3.3":
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.3.tgz#092d450db02bdb6ccb1ca8ffd47d8774a91aef87"
   integrity sha512-xsH1CJoln2r74hR+y7cg2B5JCPaTh+Hd+EbBRk9nWGSNspuo6krjhX0Om6RnRQuIvFq8wVXCLKH3kwKDYhanSg==
-
-"@babel/parser@^7.3.4":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.4.tgz#a43357e4bbf4b92a437fb9e465c192848287f27c"
-  integrity sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==
 
 "@babel/parser@^7.4.0":
   version "7.4.2"
@@ -743,6 +743,21 @@
     "@babel/parser" "^7.2.2"
     "@babel/types" "^7.2.2"
 
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.6", "@babel/traverse@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.3.4.tgz#1330aab72234f8dea091b08c4f8b9d05c7119e06"
+  integrity sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.3.4"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/parser" "^7.3.4"
+    "@babel/types" "^7.3.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.11"
+
 "@babel/traverse@^7.1.0", "@babel/traverse@^7.1.5", "@babel/traverse@^7.2.2", "@babel/traverse@^7.2.3":
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.2.3.tgz#7ff50cefa9c7c0bd2d81231fdac122f3957748d8"
@@ -757,21 +772,6 @@
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.10"
-
-"@babel/traverse@^7.1.6", "@babel/traverse@^7.3.4":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.3.4.tgz#1330aab72234f8dea091b08c4f8b9d05c7119e06"
-  integrity sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.3.4"
-    "@babel/helper-function-name" "^7.1.0"
-    "@babel/helper-split-export-declaration" "^7.0.0"
-    "@babel/parser" "^7.3.4"
-    "@babel/types" "^7.3.4"
-    debug "^4.1.0"
-    globals "^11.1.0"
-    lodash "^4.17.11"
 
 "@babel/traverse@^7.4.0":
   version "7.4.0"
@@ -1826,6 +1826,18 @@ babel-core@^6.26.0, babel-core@^6.26.3:
     private "^0.1.8"
     slash "^1.0.0"
     source-map "^0.5.7"
+
+babel-eslint@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"
+  integrity sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-generator@^6.25.0:
   version "6.25.0"
@@ -4753,7 +4765,7 @@ ember-assign-polyfill@^2.5.0, ember-assign-polyfill@^2.6.0:
     ember-cli-babel "^6.16.0"
     ember-cli-version-checker "^2.0.0"
 
-ember-auto-import@^1.2.19:
+ember-auto-import@^1.2.19, ember-auto-import@^1.2.21:
   version "1.2.21"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.2.21.tgz#e02ded183844faba66c3f2af97028ef35175b837"
   integrity sha512-coHnqO3mRnlj/JAQSQBEqzX2wL8rH5YrfEJMzk1102X9MdSX1CWeaUYBcyjvI/pG8fHUhv+4VsD6rQuhTUyZUQ==
@@ -6071,6 +6083,14 @@ eslint-plugin-prettier@^3.0.1:
   integrity sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
+
+eslint-scope@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  integrity sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
 eslint-scope@^4.0.0:
   version "4.0.0"
@@ -7445,6 +7465,11 @@ heimdalljs@^0.3.0:
   integrity sha1-6S0sb3f9RtW/ULYQ0orTF1UFTQs=
   dependencies:
     rsvp "~3.2.1"
+
+hellosign-embedded@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/hellosign-embedded/-/hellosign-embedded-1.6.1.tgz#446bfd4b36f6513bac43d553812bccc8feb3d5ce"
+  integrity sha512-6kEkrvhUUizdy9hwm/8K9Dlg1YItKEC93WccgG3qvs1XA2R9KeivdT1MaG8qmw6jcInSmWRwEtNKW1ia5nzByg==
 
 highlight.js@^9.14.2, highlight.js@^9.6.0:
   version "9.15.6"


### PR DESCRIPTION
~~This definitly needs to be documented! I'll add the documentation after merging https://github.com/he9qi/ember-cli-hellosign/pull/10~~ *EDIT: done*

How is this an enhancement? It allows us to lazy load the script at the right time in our app's lifecycle, instead of loading it at the app boot.

EDIT:
To understand how it improves the DX, I suggest reading the documentation addition.

This PR is breaking. Explanations will be detailed in the CHANGELOG to help developpers to upgrade.

@jheth do you think we could release a version `0.1.0` after merging this?

Next step will be to upgrade HelloSign to v2. This will require a bump of `ember-cli-hellosign` to v2 as well. Does it sound good to you @jheth @kiwiupover?