### PR TITLE
Pass API key to hello-sign component

### DIFF
--- a/addon/components/hello-sign.js
+++ b/addon/components/hello-sign.js
@@ -1,7 +1,5 @@
 import { assert } from '@ember/debug';
-import { isNone } from '@ember/utils';
 import Component from '@ember/component';
-import { getOwner } from '@ember/application';
 import { reads } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import layout from '../templates/components/hello-sign';
@@ -11,6 +9,7 @@ import layout from '../templates/components/hello-sign';
   ```hbs
   {{hello-sign
     url=signUrl
+    key=key
     allowCancel=false
     debug=true
     skipDomainVerification=true
@@ -39,6 +38,13 @@ export default Component.extend({
    @type String
    */
   url: null,
+
+  /**
+   * You HelloSign publishable key.
+   @argument key
+   @type String
+   */
+  key: null,
 
   // Optional attributes
 
@@ -169,18 +175,18 @@ export default Component.extend({
   init() {
     this._super(...arguments);
 
-    if (isNone(this.get('url'))) {
-      let message = [
-        'SignUrl must be set to use the hello-sign component. You can set the ',
-        'key property on the component when instantiating it in your hbs template. ',
-        'See how to get SignUrl at https://www.hellosign.com/home/myAccount#api'
-      ].join('\n');
+    let signUrlMissingMessage = [
+      'SignUrl must be set to use the hello-sign component. You can set the ',
+      'key property on the component when instantiating it in your hbs template. ',
+      'See how to get SignUrl at https://www.hellosign.com/home/myAccount#api'
+    ].join('\n');
+    assert(signUrlMissingMessage, this.get('url'));
 
-      assert(message);
-    }
+    let keyMissingMessage =
+      'Your HelloSign publishable key seems to be missing. It is required.';
+    assert(keyMissingMessage, this.get('key'));
 
-    const config = getOwner(this).resolveRegistration('config:environment');
-    this.get('hellosign').init(config.HelloSign.key);
+    this.get('hellosign').init(this.get('key'));
 
     if (!this.get('userCulture')) {
       this.set('userCulture', this.get('hellosign').CULTURES.EN_US);

--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -1,15 +1,5 @@
 # Usage
 
-## Setup
-Add your HelloSign **publishable key** to your app's config
-
-
-{{#docs-snippet name='config-environment.js' language='javascript' title='config/environment.js'}}
-  ENV.HelloSign = {
-    key: "abc"
-  };
-{{/docs-snippet}}
-
 ## Loading the library
 
 In a first step, you'll have to explicitely load the library. This addon
@@ -18,7 +8,7 @@ exposes a service to do so:
 export default class ContractController extends Controller {
   @service helloSign;
 
-  // when the user clicks on the button "Sign my contract"
+  // On user click on "Sign my contract" button
   // it may be done alternatively your route's model
   @action
   handleContractOpen() {
@@ -31,10 +21,13 @@ The loading is done through a dynamic import and uses
 [ember-auto-import](https://github.com/ef4/ember-auto-import) under the hood.
 
 ## Basic Usage
-In your template, when the library is loaded, you can use this snippet:
+In your template, once the library is loaded, you can use the following snippet.
+Two properties are required: `url` and `key`. This is detailed in the
+{{docs-link 'API REFERENCE section' 'docs.api.item' 'components/hello-sign'}}.
 ```handlebars
 {{hello-sign
   url=signUrl
+  key=key
   onEventCanceled=(action "handleEventCanceled")
   onEventError=(action "handleEventError")
   onEventSigned=(action "handleEventSigned")

--- a/tests/integration/components/hello-sign-test.js
+++ b/tests/integration/components/hello-sign-test.js
@@ -30,7 +30,23 @@ module('Integration | Component | hello sign', function(hooks) {
     // https://github.com/workmanw/ember-qunit-assert-helpers/issues/18
     const [err] = await Promise.all([
       waitForError(),
-      render(hbs`{{hello-sign}}`)
+      render(hbs`{{hello-sign key='hs-key'}}`)
+    ]);
+
+    assert.ok(err.message.includes(expectedMessage));
+  });
+
+  test('it throws error if key is not provided', async function(assert) {
+    assert.expect(1);
+
+    await this.owner.lookup('service:hello-sign').load();
+
+    let expectedMessage = 'Your HelloSign publishable key seems to be missing';
+
+    // https://github.com/workmanw/ember-qunit-assert-helpers/issues/18
+    const [err] = await Promise.all([
+      waitForError(),
+      render(hbs`{{hello-sign url='random-url'}}`)
     ]);
 
     assert.ok(err.message.includes(expectedMessage));


### PR DESCRIPTION
This PR removes the api key being set globally in `config/environment`. Instead the API key is given to the component.

This will let us to be able to sign different contract in a same app. On one page, you'll be able to provide the component with an API key. On an other one, you'll provide it with a different key.

This PR depends on https://github.com/he9qi/ember-cli-hellosign/pull/13